### PR TITLE
Fix multiple definitions linker error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 A B Compiler
 ============
 
+# ⚠ This project is not maintained anymore ⚠
+## Checkout https://github.com/aap/b for the new maintained version of a B Compiler
+
 abc is a compiler for the [B Programming Language](http://en.wikipedia.org/wiki/B_(programming_language)) that targets x86\_32 processors. It is currently tested under Linux but should work (or at least be easily ported) to other UNIX-like systems. The code is based on [an early C compiler (last1120c)](http://www.cs.bell-labs.com/who/dmr/primevalC.html) by Dennis Ritchie.
 
 Documentation

--- a/b.h
+++ b/b.h
@@ -38,26 +38,8 @@ struct	swtab {
 	int	swval;
 };
 
-struct	hshtab hshtab[HSHSIZ];
-int	hshused;
-int	eof;
-int	peekc;
-char	ctab[128];
-struct	hshtab *bsym;
-struct	hshtab *paraml, *parame;
-int	cval;
-int	isn;
-char	symbuf[NCPS+1];
-FILE	*sbufp;
-int	stack;
-struct	tnode **cp;
-int	*space;
-int	ospace[OSSIZ];
-int	retlab;
-int	nerror;
-struct	swtab swtab[SWSIZ];
-struct	swtab *swp;
-int	deflab;
+extern int  isn;
+
 extern int	contlab;
 extern int	brklab;
 

--- a/b0.c
+++ b/b0.c
@@ -1,5 +1,26 @@
 #include "b.h"
 
+int	hshused;
+int	eof;
+int	peekc;
+struct	hshtab hshtab[HSHSIZ];
+char	ctab[128];
+struct	hshtab *bsym;
+struct	hshtab *paraml, *parame;
+int	cval;
+int	isn;
+char	symbuf[NCPS+1];
+FILE	*sbufp;
+int	stack;
+struct	tnode **cp;
+int	*space;
+int	ospace[OSSIZ];
+int	retlab;
+int	nerror;
+struct	swtab swtab[SWSIZ];
+struct	swtab *swp;
+int	deflab;
+
 void extdef(void);
 struct hshtab * lookup(void);
 void blkhed(void);


### PR DESCRIPTION
Problem: When building there are a couple of errors about multiple definitions of variables because the variable are defined in the header file shared between two c files

Solution: Most of these variables were used only in b0.c so I moved them over there and one variable was used in both so I changed it to be defined as extern in the header file